### PR TITLE
remove unstranslatable string from german localised strings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Global string -->
-    <string name="app_name" translatable="false">LibreTorrent</string>
     <string name="ok">OK</string>
     <string name="cancel">Abbrechen</string>
     <string name="yes">Ja</string>


### PR DESCRIPTION
The `lintVitalRelease` gradle task fails when there's an untranslatable string in one of the localised strings files

`./gradlew lintVitalRelease` if you want to check, sample output:
```
:app:lintVitalRelease
/path/to/libretorrent/app/src/main/res/values-de/strings.xml:4: Error: Non-translatable resources should only be defined in the base values/ folder [ExtraTranslation]
    <string name="app_name" translatable="false">LibreTorrent</string>
                            ~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "ExtraTranslation":
   If a string appears in a specific language translation file, but there is
   no corresponding string in the default locale, then this string is probably
   unused. (It's technically possible that your application is only intended
   to run in a specific locale, but it's still a good idea to provide a
   fallback.).

   Note that these strings can lead to crashes if the string is looked up on
   any locale not providing a translation, so it's important to clean them
   up.

1 errors, 0 warnings
:app:lintVitalRelease FAILED
```