### PR TITLE
set 65534 as maximum port

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentEngine.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentEngine.java
@@ -74,6 +74,7 @@ public class TorrentEngine implements TorrentEngineInterface
     public static final int DEFAULT_PORT = 6881;
     public static final int DEFAULT_PROXY_PORT = 8080;
     public static final int DEFAULT_TOR_PORT = 9050;
+    public static final int MAX_PORT_NUMBER = 65534;
     public static final boolean DEFAULT_DHT_ENABLED = true;
     public static final boolean DEFAULT_LSD_ENABLED = true;
     public static final boolean DEFAULT_UTP_ENABLED = true;

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/NetworkSettingsFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/NetworkSettingsFragment.java
@@ -123,7 +123,7 @@ public class NetworkSettingsFragment extends PreferenceFragmentCompat
         bindOnPreferenceChangeListener(randomPort);
 
         InputFilter[] portFilter =
-                new InputFilter[]{ new InputFilterMinMax(0, 10000)};
+                new InputFilter[]{ new InputFilterMinMax(0, TorrentEngine.MAX_PORT_NUMBER)};
         String keyPort = getString(R.string.pref_key_port);
         EditTextPreference port = (EditTextPreference) findPreference(keyPort);
         int portNumber = pref.getInt(keyPort, -1);


### PR DESCRIPTION
close #8 .

Basically what i did here is create a new constant `MAX_PORT_NUMBER` in the `TorrentEngine`, and set the `MAX_PORT_NUMBER` in the `InputFilter`. 

As for the random port, I investigate the code and found that `pref_key_use_random_port` is not currently in use, so I thought I might leave this implementation for later. @proninyaroslav could you also take a look into this matter?