### PR TITLE
Issue #104 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     compile 'com.android.support:design:' + ANDROID_SUPPORT_VERSION
     compile 'com.android.support:cardview-v7:' + ANDROID_SUPPORT_VERSION
 
-    compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'commons-io:commons-io:2.5'
     compile 'net.grandcentrix.tray:tray:0.12.0'
     compile 'ch.acra:acra:4.9.2'

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
@@ -28,18 +28,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.net.Uri;
 import android.os.BatteryManager;
 import android.os.Build;
-import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
-import android.util.Patterns;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -54,6 +50,8 @@ import org.proninyaroslav.libretorrent.core.BencodeFileItem;
 import org.proninyaroslav.libretorrent.core.sorting.TorrentSorting;
 import org.proninyaroslav.libretorrent.settings.SettingsManager;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.regex.Matcher;
@@ -178,7 +176,7 @@ public class Utils
 
     public static String normalizeURL(String url)
     {
-        if (!Patterns.WEB_URL.matcher(url).matches()) {
+        if (!isValidUrl(url)) {
             return null;
         }
 
@@ -215,6 +213,24 @@ public class Utils
         Matcher matcher = pattern.matcher(url.trim());
 
         return matcher.matches();
+    }
+
+    /**
+     * Check whether given URL is valid.
+     * @param url URL to be checked.
+     * @return true if the URL is valid, return false otherwise.
+     */
+    public static boolean isValidUrl (String url) {
+        if (url == null || TextUtils.isEmpty(url)) {
+            return false;
+        }
+
+        try {
+            URL parsedUrl = new URL(url);
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        }
     }
 
     /*

--- a/app/src/main/java/org/proninyaroslav/libretorrent/fragments/MainFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/fragments/MainFragment.java
@@ -99,6 +99,8 @@ import org.proninyaroslav.libretorrent.settings.SettingsManager;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -741,7 +743,7 @@ public class MainFragment extends Fragment
             return true;
         }
 
-        if (!Patterns.WEB_URL.matcher(s).matches()) {
+        if (!Utils.isValidUrl(s)) {
             layout.setErrorEnabled(true);
             layout.setError(getString(R.string.error_invalid_link));
             layout.requestFocus();


### PR DESCRIPTION
fix #104 
I use java.net.URL to handle URL containing square bracket.
Additionally, I replaced SyncHttpClient  with HttpURLConnection since the SyncHttpClient has issue with handling TLS1.2 (https://github.com/loopj/android-async-http/issues/1264) and it's not maintained by its owner. 
Tested the modification with torrent from RARBG.