### PR TITLE
Modified the isListening check in the core TorrentEngine to fix Online notification

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentEngine.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentEngine.java
@@ -20,6 +20,7 @@
 package org.proninyaroslav.libretorrent.core;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -758,7 +759,9 @@ public class TorrentEngine extends SessionManager
 
     public boolean isListening()
     {
-        return swig().is_listening();
+        ConnectivityManager manager = (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        return manager.getNetworkInfo(ConnectivityManager.TYPE_WIFI).isConnected() || manager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)
+                .isConnected();
     }
 
     public boolean isDHTEnabled()


### PR DESCRIPTION
The swig().is_listening() does not seem to be checking for what we want it to be checking for when utilizing this notification. The client still has an active session and is listening even though connectivity is offline. Whether that is a defect in their library or abstract behavior, it doesn't seem necessary to use that library for this.

I just did we do in WifiReceiver and check the connectivity of wifi OR cellular to determine if the client is listening. This may break the concept of "isListening" in the app so it may be valuable to rename or create a new method if you feel. I'm not sure what is considered "listening".

Additionally, should we be checking the user's preference for wifi-only to determine what "listening" is in this method? Right now i just check if wifi or cellular is connected, because technically you CAN start a download on cellular manually if you have wifi only on. Please weigh in on this.

Let me know if this looks right to you or if the overhead of constantly creating that connectvitymanager may be negative.