### PR TITLE
Created a black theme

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/AddTorrentActivity.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/AddTorrentActivity.java
@@ -60,6 +60,9 @@ public class AddTorrentActivity extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.AppTheme_Dark);
         }
+        else if(Utils.isBlackTheme(getApplicationContext())) {
+            setTheme(R.style.AppTheme_Black);
+        }
 
         setContentView(R.layout.activity_add_torrent);
 

--- a/app/src/main/java/org/proninyaroslav/libretorrent/DetailTorrentActivity.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/DetailTorrentActivity.java
@@ -50,6 +50,10 @@ public class DetailTorrentActivity extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.AppTheme_Dark);
         }
+        else if (Utils.isBlackTheme(getApplicationContext()))
+        {
+            setTheme(R.style.AppTheme_Black);
+        }
 
         if (Utils.isTwoPane(getApplicationContext())) {
             finish();

--- a/app/src/main/java/org/proninyaroslav/libretorrent/MainActivity.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/MainActivity.java
@@ -55,6 +55,9 @@ public class MainActivity extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.AppTheme_Dark);
         }
+        else if (Utils.isBlackTheme(getApplicationContext())) {
+            setTheme(R.style.AppTheme_Black);
+        }
 
         if (getIntent().getAction() != null &&
                 getIntent().getAction().equals(NotificationReceiver.NOTIFY_ACTION_SHUTDOWN_APP)) {

--- a/app/src/main/java/org/proninyaroslav/libretorrent/RequestPermissions.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/RequestPermissions.java
@@ -59,6 +59,9 @@ public class RequestPermissions extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.Theme_AppCompat_Translucent_Dark);
         }
+        else if (Utils.isBlackTheme(getApplicationContext())) {
+            setTheme(R.style.Theme_AppCompat_Translucent_Black);
+        }
 
         if (savedInstanceState != null) {
             permDialogIsShow = savedInstanceState.getBoolean(TAG_PERM_DIALOG_IS_SHOW);

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
@@ -329,15 +329,24 @@ public class Utils
         return Utils.getBatteryLevel(context) <= Utils.getDefaultBatteryLowLevel();
     }
 
-    public static boolean isDarkTheme(Context context)
+    public static int getTheme(Context context)
     {
         SettingsManager pref = new SettingsManager(context);
-
-        int dark = Integer.parseInt(context.getString(R.string.pref_theme_dark_value));
+        
         int theme = pref.getInt(context.getString(R.string.pref_key_theme),
                                 SettingsManager.Default.theme(context));
 
-        return theme == dark;
+        return theme;
+    }
+    
+    public static boolean isDarkTheme(Context context)
+    {
+        return getTheme(context) == Integer.parseInt(context.getString(R.string.pref_theme_dark_value));
+    }
+    
+    public static boolean isBlackTheme(Context context)
+    {
+        return getTheme(context) == Integer.parseInt(context.getString(R.string.pref_theme_black_value));
     }
 
     public static TorrentSorting getTorrentSorting(Context context)

--- a/app/src/main/java/org/proninyaroslav/libretorrent/dialogs/filemanager/FileManagerDialog.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/dialogs/filemanager/FileManagerDialog.java
@@ -139,6 +139,9 @@ public class FileManagerDialog extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.AppTheme_Dark);
         }
+        else if (Utils.isDarkTheme(getApplicationContext())) {
+            setTheme(R.style.AppTheme_Black);
+        }
 
         Intent intent = getIntent();
         if (!intent.hasExtra(TAG_CONFIG)) {

--- a/app/src/main/java/org/proninyaroslav/libretorrent/fragments/DetailTorrentPeersFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/fragments/DetailTorrentPeersFragment.java
@@ -129,7 +129,7 @@ public class DetailTorrentPeersFragment extends Fragment
             };
 
             int resId = R.drawable.list_divider;
-            if (Utils.isDarkTheme(activity.getApplicationContext())) {
+            if (Utils.isDarkTheme(activity.getApplicationContext()) || Utils.isBlackTheme(activity.getApplicationContext())) {
                 resId = R.drawable.list_divider_dark;
             }
 

--- a/app/src/main/java/org/proninyaroslav/libretorrent/fragments/DetailTorrentTrackersFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/fragments/DetailTorrentTrackersFragment.java
@@ -156,10 +156,10 @@ public class DetailTorrentTrackersFragment extends Fragment
             };
 
             int resId = R.drawable.list_divider;
-            if (Utils.isDarkTheme(activity.getApplicationContext())) {
+            if (Utils.isDarkTheme(activity.getApplicationContext()) || Utils.isBlackTheme(activity.getApplicationContext())) {
                 resId = R.drawable.list_divider_dark;
             }
-
+            
             trackersList.setItemAnimator(animator);
             trackersList.addItemDecoration(
                     new RecyclerViewDividerDecoration(

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/BasePreferenceActivity.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/BasePreferenceActivity.java
@@ -47,6 +47,9 @@ public class BasePreferenceActivity extends AppCompatActivity
         if (Utils.isDarkTheme(getApplicationContext())) {
             setTheme(R.style.BaseTheme_Settings_Dark);
         }
+        else if (Utils.isBlackTheme(getApplicationContext())) {
+            setTheme(R.style.BaseTheme_Settings_Black);
+        }
 
         setContentView(R.layout.activity_settings);
 

--- a/app/src/main/res/drawable-v21/default_rect_ripple_black.xml
+++ b/app/src/main/res/drawable-v21/default_rect_ripple_black.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/background_dark">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/black"/>
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable-v21/default_round_ripple_black.xml
+++ b/app/src/main/res/drawable-v21/default_round_ripple_black.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/background_dark">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/black"/>
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/default_rect_black.xml
+++ b/app/src/main/res/drawable/default_rect_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/black"/>
+</shape>

--- a/app/src/main/res/drawable/default_rect_ripple_black.xml
+++ b/app/src/main/res/drawable/default_rect_ripple_black.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/default_rect_touch_black" android:state_selected="true"/>
+    <item android:drawable="@drawable/default_rect_touch_black" android:state_pressed="true"/>
+    <item android:drawable="@drawable/default_rect_black"/>
+</selector>

--- a/app/src/main/res/drawable/default_rect_touch_black.xml
+++ b/app/src/main/res/drawable/default_rect_touch_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/background_dark"/>
+</shape>

--- a/app/src/main/res/drawable/default_round_black.xml
+++ b/app/src/main/res/drawable/default_round_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid android:color="@color/black"/>
+</shape>

--- a/app/src/main/res/drawable/default_round_ripple_black.xml
+++ b/app/src/main/res/drawable/default_round_ripple_black.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/default_round_touch_black" android:state_selected="true"/>
+    <item android:drawable="@drawable/default_round_touch_black" android:state_pressed="true"/>
+    <item android:drawable="@drawable/default_round_black"/>
+</selector>

--- a/app/src/main/res/drawable/default_round_touch_black.xml
+++ b/app/src/main/res/drawable/default_round_touch_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid android:color="@color/background_dark"/>
+</shape>

--- a/app/src/main/res/drawable/default_select_rect_black.xml
+++ b/app/src/main/res/drawable/default_select_rect_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/background_dark"/>
+</shape>

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -12,6 +12,12 @@
         <item name="android:windowNoTitle">true</item>
     </style>
 
+    <style name="AppTheme.Black" parent="BaseTheme.Black">
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
     <style name="BaseTheme.Settings" parent="BaseTheme.BaseThemeSettings">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">false</item>
@@ -19,6 +25,12 @@
     </style>
 
     <style name="BaseTheme.Settings.Dark" parent="BaseTheme.BaseThemeSettings.Dark">
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
+    <style name="BaseTheme.Settings.Black" parent="BaseTheme.BaseThemeSettings.Black">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowNoTitle">true</item>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -10,6 +10,11 @@
         <item name="android:statusBarColor">@color/primary_dark</item>
     </style>
 
+    <style name="AppTheme.Black" parent="BaseTheme.Black">
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@color/primary_dark</item>
+    </style>
+
     <style name="BaseTheme.Toolbar.Spinner" parent="Widget.AppCompat.Light.Spinner.DropDown.ActionBar">
         <item name="android:background">@null</item>
         <item name="android:divider">@null</item>
@@ -27,6 +32,10 @@
     </style>
 
     <style name="BaseTheme.Settings.Dark" parent="BaseTheme.BaseThemeSettings.Dark">
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    </style>
+
+    <style name="BaseTheme.Settings.Black" parent="BaseTheme.BaseThemeSettings.Black">
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,4 +33,5 @@
     <color name="pieces_cell">#BDBDBD</color>
     <color name="fab_menu_shadow">#66000000</color>
     <color name="fab_menu_label_normal">#333333</color>
+    <color name="black">#000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,12 +304,15 @@
     <string-array name="pref_theme_entries">
         <item>Light</item>
         <item>Dark</item>
+        <item>Black</item>
     </string-array>
     <string name="pref_theme_light_value" translatable="false">0</string>
     <string name="pref_theme_dark_value" translatable="false">1</string>
+    <string name="pref_theme_black_value" translatable="false">2</string>
     <string-array name="pref_theme_entries_value" translatable="false">
         <item>@string/pref_theme_light_value</item>
         <item>@string/pref_theme_dark_value</item>
+        <item>@string/pref_theme_black_value</item>
     </string-array>
     <string name="pref_notification_category">Notification settings</string>
     <string name="pref_torrent_finish_notify_title">Torrent finish notification</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,9 @@
     <style name="AppTheme.Dark" parent="BaseTheme.Dark">
     </style>
 
+    <style name="AppTheme.Black" parent="BaseTheme.Black">
+    </style>
+
     <style name="BaseTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
@@ -53,6 +56,21 @@
         <item name="curOpenTorrentIndicator">@color/cur_open_torrent_indicator_dark</item>
     </style>
 
+    <style name="BaseTheme.Black" parent="BaseTheme.Dark">
+        <item name="background">@color/black</item>
+        <item name="backgroundBlank">@color/black</item>
+        <item name="android:windowBackground">@color/black</item>
+        <item name="actionBarPopupTheme">@color/black</item>
+        <item name="popupTheme">@color/black</item>
+        <item name="android:alertDialogTheme">@color/black</item>
+        <item name="alertDialogTheme">@color/black</item>
+        <item name="divider">@color/black</item>
+        <item name="defaultRectRipple">@color/black</item>
+        <item name="defaultRoundRipple">@color/black</item>
+        <item name="defaultSelectRect">@color/black</item>
+        <item name="curOpenTorrentIndicator">@color/black</item>
+    </style>
+
     <style name="BaseTheme.Dialog" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
@@ -83,6 +101,19 @@
         <item name="android:fullDark">@color/background_dialog_dark</item>
         <item name="android:topBright">@color/background_dialog_dark</item>
         <item name="android:topDark">@color/background_dialog_dark</item>
+    </style>
+
+    <style name="BaseTheme.Dialog.Black" parent="BaseTheme.Dialog.Dark">
+        <item name="android:bottomBright">@color/black</item>
+        <item name="android:bottomDark">@color/black</item>
+        <item name="android:bottomMedium">@color/black</item>
+        <item name="android:centerBright">@color/black</item>
+        <item name="android:centerDark">@color/black</item>
+        <item name="android:centerMedium">@color/black</item>
+        <item name="android:fullBright">@color/black</item>
+        <item name="android:fullDark">@color/black</item>
+        <item name="android:topBright">@color/black</item>
+        <item name="android:topDark">@color/black</item>
     </style>
 
     <style name="BaseTheme.HeaderText" parent="android:TextAppearance.Widget.TextView">
@@ -140,10 +171,18 @@
         <item name="divider">@drawable/table_mode_divider_dark</item>
     </style>
 
+    <style name="BaseTheme.BaseThemeSettings.Black" parent="BaseTheme.BaseThemeSettings.Dark">
+        <item name="colorPrimaryDark">@color/black</item>
+        <item name="android:windowBackground">@color/black</item>
+    </style>
+
     <style name="BaseTheme.Settings" parent="BaseTheme.BaseThemeSettings">
     </style>
 
     <style name="BaseTheme.Settings.Dark" parent="BaseTheme.BaseThemeSettings.Dark">
+    </style>
+
+    <style name="BaseTheme.Settings.Black" parent="BaseTheme.BaseThemeSettings.Black">
     </style>
 
     <style name="Theme.AppCompat.Translucent" parent="BaseTheme">
@@ -160,5 +199,8 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
+    <style name="Theme.AppCompat.Translucent.Black" parent="Theme.AppCompat.Translucent.Dark">
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -151,7 +151,6 @@
     </style>
 
     <style name="BaseTheme.BaseThemeSettings.Black" parent="BaseTheme.BaseThemeSettings.Dark">
-        <item name="colorPrimaryDark">@color/black</item>
         <item name="android:windowBackground">@color/black</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -60,14 +60,6 @@
         <item name="background">@color/black</item>
         <item name="backgroundBlank">@color/black</item>
         <item name="android:windowBackground">@color/black</item>
-        <item name="actionBarPopupTheme">@color/black</item>
-        <item name="popupTheme">@color/black</item>
-        <item name="android:alertDialogTheme">@color/black</item>
-        <item name="alertDialogTheme">@color/black</item>
-        <item name="divider">@color/black</item>
-        <item name="defaultRectRipple">@color/black</item>
-        <item name="defaultRoundRipple">@color/black</item>
-        <item name="defaultSelectRect">@color/black</item>
         <item name="curOpenTorrentIndicator">@color/black</item>
     </style>
 
@@ -101,19 +93,6 @@
         <item name="android:fullDark">@color/background_dialog_dark</item>
         <item name="android:topBright">@color/background_dialog_dark</item>
         <item name="android:topDark">@color/background_dialog_dark</item>
-    </style>
-
-    <style name="BaseTheme.Dialog.Black" parent="BaseTheme.Dialog.Dark">
-        <item name="android:bottomBright">@color/black</item>
-        <item name="android:bottomDark">@color/black</item>
-        <item name="android:bottomMedium">@color/black</item>
-        <item name="android:centerBright">@color/black</item>
-        <item name="android:centerDark">@color/black</item>
-        <item name="android:centerMedium">@color/black</item>
-        <item name="android:fullBright">@color/black</item>
-        <item name="android:fullDark">@color/black</item>
-        <item name="android:topBright">@color/black</item>
-        <item name="android:topDark">@color/black</item>
     </style>
 
     <style name="BaseTheme.HeaderText" parent="android:TextAppearance.Widget.TextView">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -60,6 +60,9 @@
         <item name="background">@color/black</item>
         <item name="backgroundBlank">@color/black</item>
         <item name="android:windowBackground">@color/black</item>
+        <item name="defaultRectRipple">@drawable/default_rect_ripple_black</item>
+        <item name="defaultRoundRipple">@drawable/default_round_ripple_black</item>
+        <item name="defaultSelectRect">@drawable/default_select_rect_black</item>
         <item name="curOpenTorrentIndicator">@color/black</item>
     </style>
 


### PR DESCRIPTION
Created a black theme as an option in the menu. This theme is different than the dark theme in that it uses pure black (#000000). This lets OLED-based screens turn off their pixels in the fully black areas.

* Added the appropriate checks to apply the black themes in all relevant activities
     * Split the Utils.isDarkTheme logic out into a Utils.getTheme method so Utils.isBlackTheme could leverage it as well as future themes
* Defined @color/black as #000000
* Created the appropriate option in the options menu
* Created the appropriate style, leveraging the dark theme where appropriate.
     * I kept the background of popups and dialogs from the dark theme so they can be seen against the black backgrounds they sit on. All text and accent colors are unchanged from the dark theme
* Added the appropriate drawables for the black theme

NOTE: Though I changed it and it seems fine, I do not know what `<item name="backgroundBlank">...</item>` actually is. If I should be changing that color to something different than the normal background style, let me know.