### PR TITLE
Fix  #140

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
@@ -198,9 +198,9 @@ public class TorrentTaskService extends Service
         if (wifiOnly)
             pause = !Utils.isWifiEnabled(context);
         if (onlyCharging)
-            pause &= !Utils.isBatteryCharging(context);
+            pause |= !Utils.isBatteryCharging(context);
         if (batteryControl)
-            pause &= Utils.isBatteryLow(context);
+            pause |= Utils.isBatteryLow(context);
         pauseTorrents.set(pause);
 
         if (pref.getBoolean(getString(R.string.pref_key_cpu_do_not_sleep),


### PR DESCRIPTION
Imagine pause is false and the battery is not charging. Then 

```
pause &= !Utils.isBatteryCharging(context);
```
expands to
```
pause = pause && !Utils.isBatteryCharging(context);
```
```
pause = false && true
```
```
pause = false
```

That is not the expected behaviour.

Now my change will expand to:
```
pause = false || true
```
```
pause = true
```
That is the expected behaviour.