### PR TITLE
Bugfix/shutdown after download closing after one download

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/AddTorrentActivity.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/AddTorrentActivity.java
@@ -137,7 +137,7 @@ public class AddTorrentActivity extends AppCompatActivity
             /* If add torrent dialog has been called by an implicit intent */
             if (getIntent().getData() != null && intent.hasExtra(TAG_RESULT_TORRENT)) {
                 Intent i = new Intent(getApplicationContext(), MainActivity.class);
-                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 i.putExtra(TAG_RESULT_TORRENT, intent.getParcelableExtra(TAG_RESULT_TORRENT));
                 startActivity(i);
             } else {

--- a/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
@@ -530,18 +530,28 @@ public class TorrentTaskService extends Service
                 moveTorrent(torrent);
             }
 
-            if (pref.getBoolean(getString(R.string.pref_key_shutdown_downloads_complete),
-                                SettingsManager.Default.shutdownDownloadsComplete)) {
+            if (torrentsFinished()
+                    && pref.getBoolean(
+                            getString(R.string.pref_key_shutdown_downloads_complete),
+                            SettingsManager.Default.shutdownDownloadsComplete)) {
                 if (torrentsMoveTotal != null) {
                     shutdownAfterMove = true;
                 } else {
-                    Intent shutdownIntent =
-                            new Intent(getApplicationContext(), NotificationReceiver.class);
+                    Intent shutdownIntent = new Intent(getApplicationContext(), NotificationReceiver.class);
                     shutdownIntent.setAction(NotificationReceiver.NOTIFY_ACTION_SHUTDOWN_APP);
                     sendBroadcast(shutdownIntent);
                 }
             }
         }
+    }
+
+    private boolean torrentsFinished() {
+        for (TorrentDownload torrentDownload : TorrentEngine.getInstance().getTasks()) {
+            if (torrentDownload.getStateCode().equals(TorrentStateCode.DOWNLOADING)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
* TorrentTaskService will now verify that all torrent downloads are out of the DOWNLOADING state before attempting to shut down the app
* Added the FLAG_ACTIVITY_CLEAR_TOP flag to the intent to launch MainActivity from AddTorrentActivity
    * The behavior without this causes multiple layers of MainActivity to be created, meaning the app won't fully shut down at shut down, it'll just close the top layer. This change fixes that behavior