### PR TITLE
Removed unnecessary collapseActionView value on search bar item

### DIFF
--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/search"
-        app:showAsAction="ifRoom|collapseActionView"
+        app:showAsAction="ifRoom"
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
         app:actionViewClass="android.support.v7.widget.SearchView"/>


### PR DESCRIPTION
* The collapseActionView value on the search item's showAsAction attribute was allowing it to collapse into the options menu when the search view was opened
    * The search button in the options menu was non-functional and should not have been appearing when search was opened in the action bar. Removed since it was unnecessary 


Note: This option was allowing the button to collapse into the options menu when there was not enough room on the screen for it. Since the icon is rather small, the only concern is the adjacent spinner text becoming too long on thin devices.
I imagine on a thin device, the spinner text will truncate, which should be reasonable and realistically this problem should never arise unless someone is using the Jelly phone. It should just be watched what text ends up in that spinner on the MainActivity