### PR TITLE
Feature/custom battery control

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
@@ -163,6 +163,7 @@ public class TorrentDownload
             }
         }
     }
+
     private void torrentRemoved()
     {
         if (callback != null) {

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
@@ -56,8 +56,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.frostwire.jlibtorrent.alerts.AlertType.TORRENT_PAUSED;
-
 /*
  * This class encapsulate one stream with running torrent.
  */
@@ -76,7 +74,7 @@ public class TorrentDownload
             AlertType.STATE_CHANGED.swig(),
             AlertType.TORRENT_FINISHED.swig(),
             AlertType.TORRENT_REMOVED.swig(),
-            TORRENT_PAUSED.swig(),
+            AlertType.TORRENT_PAUSED.swig(),
             AlertType.TORRENT_RESUMED.swig(),
             AlertType.STATS.swig(),
             AlertType.SAVE_RESUME_DATA.swig(),

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
@@ -91,7 +91,7 @@ public class TorrentDownload
     private File parts;
     private long lastSaveResumeTime;
 
-    private Intent batteryStatus;
+    private IntentFilter intentFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     private SettingsManager pref;
     private boolean manualResume = false;
     private boolean belowThreshold = false;
@@ -195,8 +195,7 @@ public class TorrentDownload
 
     private boolean shouldPauseDownloads()
     {
-        IntentFilter intentFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
-        batteryStatus = context.registerReceiver(null, intentFilter);
+        Intent batteryStatus = context.registerReceiver(null, intentFilter);
 
         int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
         int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/TorrentDownload.java
@@ -20,9 +20,6 @@
 package org.proninyaroslav.libretorrent.core;
 
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.os.BatteryManager;
 import android.util.Log;
 
 import com.frostwire.jlibtorrent.AlertListener;
@@ -45,10 +42,7 @@ import com.frostwire.jlibtorrent.alerts.TorrentAlert;
 import com.frostwire.jlibtorrent.swig.add_torrent_params;
 import com.frostwire.jlibtorrent.swig.byte_vector;
 
-import org.proninyaroslav.libretorrent.R;
 import org.proninyaroslav.libretorrent.core.utils.TorrentUtils;
-import org.proninyaroslav.libretorrent.core.utils.Utils;
-import org.proninyaroslav.libretorrent.settings.SettingsManager;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -91,11 +85,6 @@ public class TorrentDownload
     private File parts;
     private long lastSaveResumeTime;
 
-    private IntentFilter intentFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
-    private SettingsManager pref;
-    private boolean manualResume = false;
-    private boolean belowThreshold = false;
-
     public TorrentDownload(Context context,
                            TorrentHandle handle,
                            Torrent torrent,
@@ -110,8 +99,6 @@ public class TorrentDownload
 
         listener = new InnerListener();
         TorrentEngine.getInstance().addListener(listener);
-
-        pref = new SettingsManager(context.getApplicationContext());
     }
 
     private final class InnerListener implements AlertListener
@@ -155,7 +142,6 @@ public class TorrentDownload
                     callback.onTorrentPaused(torrent.getId());
                     break;
                 case TORRENT_RESUMED:
-                    manualResume = true;
                     callback.onTorrentResumed(torrent.getId());
                     break;
                 case STATS:
@@ -175,35 +161,8 @@ public class TorrentDownload
                     saveResumeData(false);
                     break;
             }
-
-            if(!torrent.isPaused()
-                    && pref.getBoolean(context.getString(R.string.pref_key_custom_battery_control),
-                    SettingsManager.Default.customBatteryControl)) {
-                boolean pauseDownloads = shouldPauseDownloads();
-                if(!belowThreshold && pauseDownloads) {
-                    belowThreshold = true;
-                    pause();
-                    callback.onTorrentPaused(torrent.getId());
-                }
-                if(!pauseDownloads && belowThreshold && manualResume) {
-                    manualResume = false;
-                    belowThreshold = false;
-                }
-            }
         }
     }
-
-    private boolean shouldPauseDownloads()
-    {
-        Intent batteryStatus = context.registerReceiver(null, intentFilter);
-
-        int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
-        int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
-
-        return ((level / (float) scale) * 100) <= pref.getInt(context.getString(
-                            R.string.pref_key_custom_battery_control_value), Utils.getDefaultBatteryLowLevel());
-    }
-
     private void torrentRemoved()
     {
         if (callback != null) {

--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
@@ -329,6 +329,11 @@ public class Utils
         return Utils.getBatteryLevel(context) <= Utils.getDefaultBatteryLowLevel();
     }
 
+    public static boolean isBatteryBelowThreshold(Context context, int threshold)
+    {
+        return Utils.getBatteryLevel(context) <= threshold;
+    }
+
     public static int getTheme(Context context)
     {
         SettingsManager pref = new SettingsManager(context);

--- a/app/src/main/java/org/proninyaroslav/libretorrent/receivers/PowerReceiver.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/receivers/PowerReceiver.java
@@ -43,6 +43,7 @@ public class PowerReceiver extends BroadcastReceiver
             case Intent.ACTION_BATTERY_OKAY:
             case Intent.ACTION_POWER_CONNECTED:
             case Intent.ACTION_POWER_DISCONNECTED:
+            case Intent.ACTION_BATTERY_CHANGED:
                 Intent serviceIntent = new Intent(context.getApplicationContext(), TorrentTaskService.class);
                 serviceIntent.setAction(intent.getAction());
                 context.startService(serviceIntent);
@@ -59,6 +60,17 @@ public class PowerReceiver extends BroadcastReceiver
         /* About BATTERY_LOW and BATTERY_OKAY see https://code.google.com/p/android/issues/detail?id=36712 */
         filter.addAction(Intent.ACTION_BATTERY_LOW);
         filter.addAction(Intent.ACTION_BATTERY_OKAY);
+
+        return filter;
+    }
+
+    public static IntentFilter getCustomFilter()
+    {
+        IntentFilter filter = new IntentFilter();
+
+        filter.addAction(Intent.ACTION_POWER_CONNECTED);
+        filter.addAction(Intent.ACTION_POWER_DISCONNECTED);
+        filter.addAction(Intent.ACTION_BATTERY_CHANGED);
 
         return filter;
     }

--- a/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
@@ -247,6 +247,8 @@ public class TorrentTaskService extends Service
                 Context context = getApplicationContext();
                 boolean batteryControl = pref.getBoolean(getString(R.string.pref_key_battery_control),
                                                          SettingsManager.Default.batteryControl);
+                boolean customBatteryControl = pref.getBoolean(getString(R.string.pref_key_custom_battery_control),
+                                                         SettingsManager.Default.customBatteryControl);
                 boolean onlyCharging = pref.getBoolean(getString(R.string.pref_key_download_and_upload_only_when_charging),
                                                        SettingsManager.Default.onlyCharging);
                 boolean wifiOnly = pref.getBoolean(getString(R.string.pref_key_wifi_only),
@@ -259,7 +261,7 @@ public class TorrentTaskService extends Service
                         stopSelf(startId);
                         break;
                     case Intent.ACTION_BATTERY_LOW:
-                        if (batteryControl) {
+                        if (batteryControl && !customBatteryControl) {
                             boolean pause = true;
                             if (onlyCharging)
                                 pause &= !Utils.isBatteryCharging(context);
@@ -272,7 +274,7 @@ public class TorrentTaskService extends Service
                         }
                         break;
                     case Intent.ACTION_BATTERY_OKAY:
-                        if (batteryControl) {
+                        if (batteryControl && !customBatteryControl) {
                             boolean resume = true;
                             if (onlyCharging)
                                 resume &= Utils.isBatteryCharging(context);
@@ -656,11 +658,13 @@ public class TorrentTaskService extends Service
             if (item.module().equals(SettingsManager.MODULE_NAME)) {
                 Context context = getApplicationContext();
                 if (item.key().equals(getString(R.string.pref_key_battery_control)) ||
-                    item.key().equals(getString(R.string.pref_key_download_and_upload_only_when_charging)) ||
-                    item.key().equals(getString(R.string.pref_key_wifi_only))) {
+                        item.key().equals(getString(R.string.pref_key_download_and_upload_only_when_charging)) ||
+                        item.key().equals(getString(R.string.pref_key_wifi_only))) {
 
                     boolean batteryControl = pref.getBoolean(getString(R.string.pref_key_battery_control),
                                                              SettingsManager.Default.batteryControl);
+                    boolean customBatteryControl = pref.getBoolean(getString(R.string.pref_key_custom_battery_control),
+                                                             SettingsManager.Default.customBatteryControl);
                     boolean onlyCharging = pref.getBoolean(getString(R.string.pref_key_download_and_upload_only_when_charging),
                                                            SettingsManager.Default.onlyCharging);
                     boolean wifiOnly = pref.getBoolean(getString(R.string.pref_key_wifi_only),
@@ -686,7 +690,7 @@ public class TorrentTaskService extends Service
                         pause = !Utils.isWifiEnabled(context);
                     if (onlyCharging)
                         pause &= !Utils.isBatteryCharging(context);
-                    if (batteryControl)
+                    if (batteryControl && !customBatteryControl)
                         pause &= Utils.isBatteryLow(context);
                     if (pause) {
                         pauseTorrents.set(true);

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
@@ -19,10 +19,13 @@
 
 package org.proninyaroslav.libretorrent.settings;
 
+import android.app.AlertDialog;
 import android.content.ComponentName;
+import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v7.preference.Preference;
+import android.support.v7.preference.SeekBarPreference;
 import android.support.v7.preference.SwitchPreferenceCompat;
 
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
@@ -80,6 +83,20 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
         batteryControl.setChecked(pref.getBoolean(keyBatteryControl, SettingsManager.Default.batteryControl));
         bindOnPreferenceChangeListener(batteryControl);
 
+        String keyCustomBatteryControl = getString(R.string.pref_key_custom_battery_control);
+        SwitchPreferenceCompat customBatteryControl = (SwitchPreferenceCompat) findPreference(keyCustomBatteryControl);
+        customBatteryControl.setSummary(String.format(getString(R.string.pref_custom_battery_control_summary),
+                Utils.getDefaultBatteryLowLevel()));
+        customBatteryControl.setChecked(pref.getBoolean(keyCustomBatteryControl, SettingsManager.Default.customBatteryControl));
+        bindOnPreferenceChangeListener(customBatteryControl);
+
+        String keyCustomBatteryControlValue = getString(R.string.pref_key_custom_battery_control_value);
+        SeekBarPreference customBatteryControlValue = (SeekBarPreference) findPreference(keyCustomBatteryControlValue);
+        customBatteryControlValue.setValue(pref.getInt(keyCustomBatteryControlValue, Utils.getDefaultBatteryLowLevel()));
+        customBatteryControlValue.setMin(10);
+        customBatteryControlValue.setMax(90);
+        bindOnPreferenceChangeListener(customBatteryControlValue);
+
         String keyWifiOnly = getString(R.string.pref_key_wifi_only);
         SwitchPreferenceCompat wifiOnly = (SwitchPreferenceCompat) findPreference(keyWifiOnly);
         wifiOnly.setChecked(pref.getBoolean(keyWifiOnly, SettingsManager.Default.wifiOnly));
@@ -98,7 +115,7 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
     }
 
     @Override
-    public boolean onPreferenceChange(Preference preference, Object newValue)
+    public boolean onPreferenceChange(final Preference preference, Object newValue)
     {
         SettingsManager pref = new SettingsManager(getActivity().getApplicationContext());
 
@@ -114,6 +131,29 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
                 getActivity().getPackageManager()
                         .setComponentEnabledSetting(bootReceiver, flag, PackageManager.DONT_KILL_APP);
             }
+
+            if(preference.getKey().equals(getString(R.string.pref_key_custom_battery_control))) {
+                if (!((SwitchPreferenceCompat) preference).isChecked()) {
+                    new AlertDialog.Builder(getContext())
+                            .setTitle(getString(R.string.warning))
+                            .setMessage(getString(R.string.pref_custom_battery_control_dialog_summary))
+                            .setCancelable(false)
+                            .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog, int id) {
+                                    dialog.dismiss();
+                                }
+                            })
+                            .setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog, int id) {
+                                    ((SwitchPreferenceCompat) preference).setChecked(false);
+                                }
+                            })
+                            .create()
+                            .show();
+                }
+            }
+        } else if (preference instanceof SeekBarPreference) {
+            pref.put(preference.getKey(), (int) newValue);
         }
 
         return true;

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
@@ -117,7 +117,7 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
     @Override
     public boolean onPreferenceChange(final Preference preference, Object newValue)
     {
-        SettingsManager pref = new SettingsManager(getActivity().getApplicationContext());
+        final SettingsManager pref = new SettingsManager(getActivity().getApplicationContext());
 
         if (preference instanceof SwitchPreferenceCompat) {
             pref.put(preference.getKey(), (boolean) newValue);
@@ -136,7 +136,7 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
                     disableBatteryControl(pref);
             }
             if(preference.getKey().equals(getString(R.string.pref_key_battery_control))) {
-                if(!((SwitchPreferenceCompat) preference).isChecked())
+                if(((SwitchPreferenceCompat) preference).isChecked())
                     disableCustomBatteryControl(pref);
             }
             if(preference.getKey().equals(getString(R.string.pref_key_custom_battery_control))) {
@@ -152,7 +152,7 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
                             })
                             .setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int id) {
-                                    ((SwitchPreferenceCompat) preference).setChecked(false);
+                                    disableCustomBatteryControl(pref);
                                 }
                             })
                             .create()

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
@@ -131,7 +131,14 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
                 getActivity().getPackageManager()
                         .setComponentEnabledSetting(bootReceiver, flag, PackageManager.DONT_KILL_APP);
             }
-
+            if(preference.getKey().equals(getString(R.string.pref_key_download_and_upload_only_when_charging))) {
+                if(!((SwitchPreferenceCompat) preference).isChecked())
+                    disableBatteryControl(pref);
+            }
+            if(preference.getKey().equals(getString(R.string.pref_key_battery_control))) {
+                if(!((SwitchPreferenceCompat) preference).isChecked())
+                    disableCustomBatteryControl(pref);
+            }
             if(preference.getKey().equals(getString(R.string.pref_key_custom_battery_control))) {
                 if (!((SwitchPreferenceCompat) preference).isChecked()) {
                     new AlertDialog.Builder(getContext())
@@ -157,5 +164,22 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
         }
 
         return true;
+    }
+
+    private void disableBatteryControl(SettingsManager pref)
+    {
+        String keyBatteryControl = getString(R.string.pref_key_battery_control);
+        SwitchPreferenceCompat batteryControl = (SwitchPreferenceCompat) findPreference(keyBatteryControl);
+        batteryControl.setChecked(false);
+        pref.put(batteryControl.getKey(), false);
+        disableCustomBatteryControl(pref);
+    }
+
+    private void disableCustomBatteryControl(SettingsManager pref)
+    {
+        String keyCustomBatteryControl = getString(R.string.pref_key_custom_battery_control);
+        SwitchPreferenceCompat batteryControl = (SwitchPreferenceCompat) findPreference(keyCustomBatteryControl);
+        batteryControl.setChecked(false);
+        pref.put(batteryControl.getKey(), false);
     }
 }

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/SettingsManager.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/SettingsManager.java
@@ -52,6 +52,7 @@ public class SettingsManager extends TrayPreferences
         public static final boolean cpuDoNotSleep = false;
         public static final boolean onlyCharging = false;
         public static final boolean batteryControl = false;
+        public static final boolean customBatteryControl = false;
         public static final boolean wifiOnly = false;
         /* Network settings */
         public static final int port = TorrentEngine.Settings.DEFAULT_PORT;

--- a/app/src/main/res/values/pref_keys.xml
+++ b/app/src/main/res/values/pref_keys.xml
@@ -36,6 +36,8 @@
     <string name="pref_key_cpu_do_not_sleep" translatable="false">pref_key_cpu_do_not_sleep</string>
     <string name="pref_key_download_and_upload_only_when_charging" translatable="false">pref_key_download_and_upload_only_when_charging</string>
     <string name="pref_key_battery_control" translatable="false">pref_key_battery_control</string>
+    <string name="pref_key_custom_battery_control" translatable="false">pref_key_custom_battery_control</string>
+    <string name="pref_key_custom_battery_control_value" translatable="false">pref_key_custom_battery_control_value</string>
     <string name="pref_key_wifi_only" translatable="false">pref_key_wifi_only</string>
     <string name="pref_key_foreground_notify_func_button" translatable="false">pref_key_foreground_notify_func_button</string>
     <!-- Network settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="error">Error</string>
+    <string name="warning">Warning</string>
     <string name="shutdown">Shutdown</string>
     <string name="replace">Replace</string>
     <string name="add">Add</string>
@@ -347,7 +348,11 @@
     <string name="pref_download_and_upload_only_when_charging_title">Download and upload only when charging</string>
     <string name="pref_download_and_upload_only_when_charging_summary">If enabled, torrents will download/upload only when charging. All torrents will pause when not connected to charger</string>
     <string name="pref_battery_control_title">Battery control</string>
+    <string name="pref_custom_battery_control_title">Unlock battery control</string>
+    <string name="pref_custom_battery_control_value_title">Battery control percentage</string>
     <string name="pref_battery_control_summary" formatted="false">All torrents will be paused if the battery level goes below %1$d%%. Limit doesn\'t apply at the time of charging</string>
+    <string name="pref_custom_battery_control_summary" formatted="false">Set a custom percentage to pause downloads at if the battery drops below the given threshold. Enabling this will ignore the default %1$d%% threshold.</string>
+    <string name="pref_custom_battery_control_dialog_summary" formatted="false">Setting a custom battery percentage for the application to watch for will have a negative impact on battery life while downloads are occurring. Are you sure you want to enable this?</string>
     <!-- Network settings -->
     <string name="pref_proxy_settings_title">Proxy settings</string>
     <string name="pref_enable_dht_title">Enable DHT</string>

--- a/app/src/main/res/xml/pref_behavior.xml
+++ b/app/src/main/res/xml/pref_behavior.xml
@@ -32,13 +32,15 @@
             android:key="@string/pref_key_download_and_upload_only_when_charging"
             android:title="@string/pref_download_and_upload_only_when_charging_title"
             android:summary="@string/pref_download_and_upload_only_when_charging_summary"
-            android:persistent="false" />
+            android:persistent="false"
+            android:disableDependentsState="true"/>
 
         <SwitchPreferenceCompat
             android:key="@string/pref_key_battery_control"
             android:title="@string/pref_battery_control_title"
             android:summary="@string/pref_battery_control_summary"
-            android:persistent="false" />
+            android:persistent="false"
+            android:dependency="@string/pref_key_download_and_upload_only_when_charging" />
         <SwitchPreferenceCompat
             android:key="@string/pref_key_custom_battery_control"
             android:title="@string/pref_custom_battery_control_title"

--- a/app/src/main/res/xml/pref_behavior.xml
+++ b/app/src/main/res/xml/pref_behavior.xml
@@ -39,5 +39,16 @@
             android:title="@string/pref_battery_control_title"
             android:summary="@string/pref_battery_control_summary"
             android:persistent="false" />
+        <SwitchPreferenceCompat
+            android:key="@string/pref_key_custom_battery_control"
+            android:title="@string/pref_custom_battery_control_title"
+            android:summary="@string/pref_custom_battery_control_summary"
+            android:persistent="false"
+            android:dependency="@string/pref_key_battery_control" />
+        <SeekBarPreference
+            android:key="@string/pref_key_custom_battery_control_value"
+            android:title="@string/pref_custom_battery_control_value_title"
+            android:persistent="false"
+            android:dependency="@string/pref_key_custom_battery_control" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
* Added settings options to set a custom battery percentage to stop downloads at
    * There is a switch preference that is disabled unless you enable the battery control key
        * Enabling this switch pops a dialog that explains that using this feature will consume additional battery
    * There is a seekbar preference that is disabled unless you enable the custom battery control key
        * The range of this preference is 10 - 90 to avoid errors in the math for pausing
        * The textview displaying the value does not update in real time, only after setting the value
* Added logic to the TorrentTaskService to handle not pausing downloads at the regular 15% interval if the custom battery control key is enabled
* Added logic to TorrentDownload to handle pausing downloads when the custom battery control threshold is pased
    * If a user manually resumes a download, it will not automatically pause again until after the threshold is passed again (charged then discharged). This is identical to current behavior