### PR TITLE
Added support for adding an infohash directly to the Add Link option

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/core/utils/Utils.java
@@ -68,6 +68,7 @@ public class Utils
     public static final String MAGNET_PREFIX = "magnet";
     public static final String HTTP_PREFIX = "http";
     public static final String HTTPS_PREFIX = "https";
+    public static final String INFOHASH_PREFIX = "magnet:?xt=urn:btih:";
     public static final String FILE_PREFIX = "file";
     public static final String CONTENT_PREFIX = "content";
     public static final String TRACKER_URL_PATTERN =

--- a/app/src/main/java/org/proninyaroslav/libretorrent/fragments/MainFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/fragments/MainFragment.java
@@ -746,12 +746,14 @@ public class MainFragment extends Fragment
             return true;
         }
 
-        if (!Utils.isValidUrl(s)) {
-            layout.setErrorEnabled(true);
-            layout.setError(getString(R.string.error_invalid_link));
-            layout.requestFocus();
+        if (s.startsWith(Utils.HTTP_PREFIX) || s.startsWith(Utils.HTTPS_PREFIX)) {
+            if (!Utils.isValidUrl(s)) {
+                layout.setErrorEnabled(true);
+                layout.setError(getString(R.string.error_invalid_link));
+                layout.requestFocus();
 
-            return false;
+                return false;
+            }
         }
 
         layout.setErrorEnabled(false);
@@ -933,8 +935,11 @@ public class MainFragment extends Fragment
 
                         if (link.startsWith(Utils.MAGNET_PREFIX)) {
                             url = link;
-                        } else {
+                        } else if (link.startsWith(Utils.HTTP_PREFIX)
+                                || link.startsWith(Utils.HTTPS_PREFIX)) {
                             url = Utils.normalizeURL(link);
+                        } else {
+                            url = Utils.INFOHASH_PREFIX + link;
                         }
 
                         if (url != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="force_recheck_torrent">Force recheck</string>
     <string name="force_announce_torrent">Force announce</string>
     <string name="add_link">Add link</string>
-    <string name="dialog_add_link_title">Enter the magnet, infohash, or HTTP/HTTPS link</string>
+    <string name="dialog_add_link_title">Enter the infohash value, magnet link, or HTTP/HTTPS link</string>
     <string name="torrent_list_empty">No torrents</string>
     <string name="select_or_add_torrent">Select or add a torrent</string>
     <string name="error_empty_link">Please enter link</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="force_recheck_torrent">Force recheck</string>
     <string name="force_announce_torrent">Force announce</string>
     <string name="add_link">Add link</string>
-    <string name="dialog_add_link_title">Enter the magnet or HTTP/HTTPS link</string>
+    <string name="dialog_add_link_title">Enter the magnet, infohash, or HTTP/HTTPS link</string>
     <string name="torrent_list_empty">No torrents</string>
     <string name="select_or_add_torrent">Select or add a torrent</string>
     <string name="error_empty_link">Please enter link</string>


### PR DESCRIPTION
* A user can now type the infohash of a torrent directly into "Add Link" and it will add the torrent
     * Any string not containing the MAGNET_PREFIX or HTTP(S)_PREFIX will automatically attempt to convert to an infohash using the new INFOHASH_PREFIX