### PR TITLE
Feature/disable keep alive

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/services/TorrentTaskService.java
@@ -353,8 +353,10 @@ public class TorrentTaskService extends Service
         /* The first start */
         isAlreadyRunning = true;
 
-        makeForegroundNotify();
-        startUpdateForegroundNotify();
+        if(pref.getBoolean(getString(R.string.pref_key_keep_alive), SettingsManager.Default.keepAlive)) {
+            makeForegroundNotify();
+            startUpdateForegroundNotify();
+        }
 
         return START_STICKY;
     }
@@ -734,6 +736,15 @@ public class TorrentTaskService extends Service
                     TorrentEngine.Settings s = TorrentEngine.getInstance().getSettings();
                     s.activeLimit = pref.getInt(item.key(), SettingsManager.Default.maxActiveTorrents);
                     TorrentEngine.getInstance().setSettings(s);
+                } else if (item.key().equals(getString(R.string.pref_key_keep_alive))) {
+                    if(pref.getBoolean(getString(R.string.pref_key_keep_alive),
+                            SettingsManager.Default.keepAlive)) {
+                        makeForegroundNotify();
+                        startUpdateForegroundNotify();
+                    } else {
+                        stopForegroundNotify();
+                        stopUpdateForegroundNotify();
+                    }
                 } else if (item.key().equals(getString(R.string.pref_key_cpu_do_not_sleep))) {
                     setKeepCpuAwake(pref.getBoolean(getString(R.string.pref_key_cpu_do_not_sleep),
                                     SettingsManager.Default.cpuDoNotSleep));
@@ -1628,7 +1639,7 @@ public class TorrentTaskService extends Service
                         PendingIntent.FLAG_UPDATE_CURRENT);
 
         foregroundNotify = new NotificationCompat.Builder(getApplicationContext(),
-                                                          FOREGROUND_NOTIFY_CHAN_ID)
+                FOREGROUND_NOTIFY_CHAN_ID)
                 .setSmallIcon(R.drawable.ic_app_notification)
                 .setContentIntent(startupPendingIntent)
                 .setContentTitle(getString(R.string.app_running_in_the_background))
@@ -1645,6 +1656,11 @@ public class TorrentTaskService extends Service
 
         /* Disallow killing the service process by system */
         startForeground(SERVICE_STARTED_NOTIFICATION_ID, foregroundNotify.build());
+    }
+
+    private void stopForegroundNotify() {
+        foregroundNotify = null;
+        stopForeground(true);
     }
 
     /*

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/BehaviorSettingsFragment.java
@@ -58,6 +58,11 @@ public class BehaviorSettingsFragment extends PreferenceFragmentCompat
         autostart.setChecked(pref.getBoolean(keyAutostart, SettingsManager.Default.autostart));
         bindOnPreferenceChangeListener(autostart);
 
+        String keyKeepAlive = getString(R.string.pref_key_keep_alive);
+        SwitchPreferenceCompat keepAlive = (SwitchPreferenceCompat) findPreference(keyKeepAlive);
+        keepAlive.setChecked(pref.getBoolean(keyKeepAlive, SettingsManager.Default.keepAlive));
+        bindOnPreferenceChangeListener(keepAlive);
+
         String keyShutdownComplete = getString(R.string.pref_key_shutdown_downloads_complete);
         SwitchPreferenceCompat shutdownComplete = (SwitchPreferenceCompat) findPreference(keyShutdownComplete);
         shutdownComplete.setChecked(pref.getBoolean(keyShutdownComplete, SettingsManager.Default.shutdownDownloadsComplete));

--- a/app/src/main/java/org/proninyaroslav/libretorrent/settings/SettingsManager.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/settings/SettingsManager.java
@@ -48,6 +48,7 @@ public class SettingsManager extends TrayPreferences
         public static int funcButton(Context context) { return Integer.parseInt(context.getString(R.string.pref_function_button_pause_value)); }
         /* Behavior settings */
         public static final boolean autostart = false;
+        public static final boolean keepAlive = true;
         public static final boolean shutdownDownloadsComplete = false;
         public static final boolean cpuDoNotSleep = false;
         public static final boolean onlyCharging = false;

--- a/app/src/main/res/values/pref_keys.xml
+++ b/app/src/main/res/values/pref_keys.xml
@@ -32,6 +32,7 @@
     <string name="pref_key_led_indicator_notify" translatable="false">pref_key_led_indicator_notify</string>
     <string name="pref_key_led_indicator_color_notify" translatable="false">pref_key_led_indicator_color_notify</string>
     <string name="pref_key_vibration_notify" translatable="false">pref_key_vibration_notify</string>
+    <string name="pref_key_keep_alive" translatable="false">pref_key_keep_alive</string>
     <string name="pref_key_shutdown_downloads_complete" translatable="false">pref_key_shutdown_downloads_complete</string>
     <string name="pref_key_cpu_do_not_sleep" translatable="false">pref_key_cpu_do_not_sleep</string>
     <string name="pref_key_download_and_upload_only_when_charging" translatable="false">pref_key_download_and_upload_only_when_charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,8 @@
     <string name="pref_wifi_only_title">Wi-Fi only</string>
     <string name="pref_wifi_only_summary">Download and upload only if Wi-Fi is connected</string>
     <string name="pref_power_management_category">Power management</string>
+    <string name="pref_keep_alive_title">Keep Alive</string>
+    <string name="pref_keep_alive_summary">If enabled, the application will remain running in the background when no torrents are downloading.</string>
     <string name="pref_shutdown_downloads_complete_title">Shutdown when downloads complete</string>
     <string name="pref_shutdown_downloads_complete_summary">If enabled, the app will shutdown when all downloads have completed</string>
     <string name="pref_cpu_do_not_sleep_title">Keep CPU awake</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,8 +340,8 @@
     <string name="pref_wifi_only_title">Wi-Fi only</string>
     <string name="pref_wifi_only_summary">Download and upload only if Wi-Fi is connected</string>
     <string name="pref_power_management_category">Power management</string>
-    <string name="pref_keep_alive_title">Keep Alive</string>
-    <string name="pref_keep_alive_summary">If enabled, the application will remain running in the background when no torrents are downloading.</string>
+    <string name="pref_keep_alive_title">Keep alive</string>
+    <string name="pref_keep_alive_summary">If enabled, the application will remain running in the background when no torrents are downloading. Shutdown when downloads complete is still respected.</string>
     <string name="pref_shutdown_downloads_complete_title">Shutdown when downloads complete</string>
     <string name="pref_shutdown_downloads_complete_summary">If enabled, the app will shutdown when all downloads have completed</string>
     <string name="pref_cpu_do_not_sleep_title">Keep CPU awake</string>

--- a/app/src/main/res/xml/pref_behavior.xml
+++ b/app/src/main/res/xml/pref_behavior.xml
@@ -17,6 +17,12 @@
         android:title="@string/pref_power_management_category">
 
         <SwitchPreferenceCompat
+            android:key="@string/pref_key_keep_alive"
+            android:title="@string/pref_keep_alive_title"
+            android:summary="@string/pref_keep_alive_summary"
+            android:persistent="false" />
+
+        <SwitchPreferenceCompat
             android:key="@string/pref_key_shutdown_downloads_complete"
             android:title="@string/pref_shutdown_downloads_complete_title"
             android:summary="@string/pref_shutdown_downloads_complete_summary"


### PR DESCRIPTION
Added an option that allows users to disable the foreground notification / task that keeps the application alive in the background while no torrents are downloading
* Fixed how torrentsFinished() handles verifying torrents are downloading
* Added an option in behavior settings that lets the user disable/enable the keep alive settings
    * When disabled, the notification/task will be removed when all torrents complete their downloads
    * When enabled, previous behavior is retained
* This change does not affect the Shutdown when downloads complete settings

Note, this does not shut the application, it just disables the notification/task that keeps the application running in the background when no torrents are downloading