### PR TITLE
Change method name 'set' to 'addCookie'

### DIFF
--- a/app/src/main/java/org/nanohttpd/protocols/http/content/CookieHandler.java
+++ b/app/src/main/java/org/nanohttpd/protocols/http/content/CookieHandler.java
@@ -93,7 +93,7 @@ public class CookieHandler implements Iterable<String> {
         return this.cookies.get(name);
     }
 
-    public void set(Cookie cookie) {
+    public void addCookie(Cookie cookie) {
         this.queue.add(cookie);
     }
 


### PR DESCRIPTION
This class is used to handle cookie.  This method named 'set' is to add cookie. Thus, the method name 'addCookie' is more intuitive than 'set'.