### PR TITLE
fix addButton crash in a specific behavior

### DIFF
--- a/app/src/main/java/org/proninyaroslav/libretorrent/ui/createtorrent/CreateTorrentDialog.java
+++ b/app/src/main/java/org/proninyaroslav/libretorrent/ui/createtorrent/CreateTorrentDialog.java
@@ -302,7 +302,15 @@ public class CreateTorrentDialog extends DialogFragment
 
             cancelButton.setOnClickListener((v) ->
                     finish(new Intent(), FragmentCallback.ResultCode.CANCEL));
-            addButton.setOnClickListener((v) -> choosePathToSaveDialog());
+            addButton.setOnClickListener((v) -> {
+                if(TextUtils.isEmpty(viewModel.mutableParams.getSeedPathName()) || "null".equals(viewModel.mutableParams.getSeedPathName())) {
+                    binding.layoutFileOrDirPath.setErrorEnabled(true);
+                    binding.layoutFileOrDirPath.setError(getText(R.string.error_please_select_file_or_folder_for_seeding_first));
+                }
+                else{
+                    choosePathToSaveDialog();
+                }
+            });
         });
     }
 
@@ -487,6 +495,9 @@ public class CreateTorrentDialog extends DialogFragment
                 return;
             }
 
+            binding.layoutFileOrDirPath.setErrorEnabled(false);
+            binding.layoutFileOrDirPath.setError(null);
+            
             viewModel.mutableParams.getSeedPath().set(data.getData());
 
         } else if (requestCode == CHOOSE_PATH_TO_SAVE_REQUEST) {


### PR DESCRIPTION
fix addButton crash in a specific behavior
How to reproduce this bug:
1. open app;
2. open Create Torrent Dialog;
3. Click the add button directly；
4. crash;
because of the File Or Dir Path have not selected.

so, I add some code to fix this bug and add one string for error notice.

Your project is great!