### PR TITLE
fix addButton crash in a specific behavior

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,6 +328,7 @@
     <string name="create_torrent">Create torrent</string>
     <string name="creating_torrent_progress">Creating torrent, please wait&#8230;</string>
     <string name="file_or_folder_for_seeding">File or folder for seeding</string>
+    <string name="error_please_select_file_or_folder_for_seeding_first">Please select file or folder for seeding first</string>
     <string name="tracker_urls">Tracker URLs</string>
     <string name="web_seed_urls">Web seed URLs</string>
     <string name="comments">Comments</string>


### PR DESCRIPTION
fix addButton crash in a specific behavior
How to reproduce this bug:
1. open app;
2. open Create Torrent Dialog;
3. Click the add button directly；
4. crash;
because of the File Or Dir Path have not selected.

so, I add some code to fix this bug and add one string for error notice.

Your project is great!