### PR TITLE
fix addButton crash in a specific behavior

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -306,8 +306,9 @@
     <string name="feed_item_url_not_found">找不到URL</string>
     <!-- Create torrent dialog -->
     <string name="create_torrent">创建BT种子</string>
-    <string name="creating_torrent_progress">正在创建种子，请稍候&amp;#8230；</string>
+    <string name="creating_torrent_progress">正在创建种子，请稍候&#8230;</string>
     <string name="file_or_folder_for_seeding">需要做种的文件或文件夹</string>
+    <string name="error_please_select_file_or_folder_for_seeding_first">请先选择需要做种的文件或文件夹</string>
     <string name="tracker_urls">tracker追踪器链接</string>
     <string name="web_seed_urls">种子链接</string>
     <string name="comments">评论</string>


### PR DESCRIPTION
fix addButton crash in a specific behavior
How to reproduce this bug:
1. open app;
2. open Create Torrent Dialog;
3. Click the add button directly；
4. crash;
because of the File Or Dir Path have not selected.

so, I add some code to fix this bug and add one string for error notice.

Your project is great!

by the way, I fixed a translate issus:
string: creating_torrent_progress:
fix &amp;#8230；to &#8230;