### PR TITLE
Changed layout_width in dialog_change_priority.xml

### DIFF
--- a/app/src/main/res/layout/dialog_change_priority.xml
+++ b/app/src/main/res/layout/dialog_change_priority.xml
@@ -8,21 +8,21 @@
 
     <RadioButton
         android:id="@+id/dialog_priority_low"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="48dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:text="@string/change_priority_low" />
 
     <RadioButton
         android:id="@+id/dialog_priority_normal"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="48dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:text="@string/change_priority_normal" />
 
     <RadioButton
         android:id="@+id/dialog_priority_high"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="48dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:text="@string/change_priority_high" />


### PR DESCRIPTION
I changed the layout_width  from wrap_content to match_parent because my fingers can't reach with one handed and it is annoying me.

Before (wrap_content)
[torrent-priority-wrap-content.webm](https://github.com/proninyaroslav/libretorrent/assets/26008581/d937bb88-1bda-46d8-948f-6c5582e5f06c)

After (match_parent)
[torrent-priority-match-parent-2.webm](https://github.com/proninyaroslav/libretorrent/assets/26008581/45c5e78a-5804-4e6c-8dee-db8e3b70df70)

