### PR TITLE
Fix typo in German string resource

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -549,7 +549,7 @@
     <string name="pref_foreground_notify_status_filter">Statusfilter</string>
     <string name="pref_foreground_notify_sorting_entries_6">Fortschritt (kleinster zuerst)</string>
     <string name="pref_foreground_notify_sorting_entries_0">Name (A-Z)</string>
-    <string name="pref_foreground_notify_sorting_entries_7">Fortdchritt (größter zuerst)</string>
+    <string name="pref_foreground_notify_sorting_entries_7">Fortschritt (größter zuerst)</string>
     <string name="pref_foreground_notify_sorting_entries_10">Beliebtheit (niedrigste zuerst)</string>
     <string name="pref_default_trackers_list_title">Standard-Tracker</string>
     <string name="pref_foreground_notify_sorting_entries_2">Hinzugefügt (neueste zuerst)</string>


### PR DESCRIPTION
Simply fixed the word "Fortdchritt" to correct word: "Fortschritt".